### PR TITLE
feat: add basic auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,16 @@ The following example config shows how to set up the data layer.
 }
 ```
 
+### Environment overrides
+
+The SPARQL connection settings, including basic authentication, can also be
+provided through environment variables:
+
+- `SPARQL_QUERY_ENDPOINT`
+- `SPARQL_UPDATE_ENDPOINT`
+- `SPARQL_USER`
+- `SPARQL_SECRET`
+
+If these variables are set they will override the corresponding values in the
+configuration file.
+


### PR DESCRIPTION
## Summary
- support basic authentication for SPARQL queries and updates
- allow overriding SPARQL endpoint and credentials via environment variables
- document available environment variables

## Testing
- `go test ./...` *(fails: could not send request: Post "http://localhost:7200/repositories/test_layer/statements": dial tcp [::1]:7200: connect: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689b2319980c832cb10d8deb2aacb5f6