### PR TITLE
Use GRAPH clauses in SPARQL update template

### DIFF
--- a/layer.go
+++ b/layer.go
@@ -793,19 +793,24 @@ type UpdateData struct {
 }
 
 const updateTemplateText = `
-WITH <{{ .Graph }}> 
 DELETE {
-	?subject ?predicate ?object
+    GRAPH <{{ .Graph }}> {
+        ?subject ?predicate ?object
+    }
 }
 INSERT {
-	{{ .InsertTriples }} 
+    GRAPH <{{ .Graph }}> {
+        {{ .InsertTriples }}
+    }
 }
 WHERE {
-	VALUES ?subject { {{ .ToDeleteResources }} }
-	BIND(NOW() AS ?now)
-	OPTIONAL {
-		?subject ?predicate ?object
-	}
+    VALUES ?subject { {{ .ToDeleteResources }} }
+    BIND(NOW() AS ?now)
+    OPTIONAL {
+        GRAPH <{{ .Graph }}> {
+            ?subject ?predicate ?object
+        }
+    }
 }`
 
 const insertTemplateText = `

--- a/update_template_test.go
+++ b/update_template_test.go
@@ -1,0 +1,30 @@
+package layer
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"text/template"
+)
+
+func TestUpdateTemplateUsesGraph(t *testing.T) {
+	data := UpdateData{
+		Graph:             "http://example.org/people",
+		InsertTriples:     "<s1> <p1> <o1> .",
+		ToDeleteResources: "<s1>",
+	}
+
+	tplt := template.Must(template.New("sparqlUpdate").Parse(updateTemplateText))
+	var buf bytes.Buffer
+	if err := tplt.Execute(&buf, data); err != nil {
+		t.Fatal(err)
+	}
+	result := buf.String()
+
+	if strings.Contains(result, "WITH") {
+		t.Errorf("expected no WITH clause, got: %s", result)
+	}
+	if count := strings.Count(result, "GRAPH <"+data.Graph+">"); count != 3 {
+		t.Errorf("expected 3 GRAPH clauses, got %d: %s", count, result)
+	}
+}


### PR DESCRIPTION
## Summary
- switch update template to explicit GRAPH clauses instead of USING WITH
- test that update template includes GRAPH clauses and avoids WITH

## Testing
- `go test ./...` *(fails: hangs waiting for SPARQL service)*
- `go test -run TestUpdateTemplateUsesGraph -count=1`


------
https://chatgpt.com/codex/tasks/task_e_689d6d88822c832cb6c670b922c7ba60